### PR TITLE
Add simple spell checking CLI tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
 # Correxxt1
-1
+
+Correxxt1 is a simple command-line spell checking tool built with Python.
+It uses the [`pyspellchecker`](https://pyspellchecker.readthedocs.io/) library
+to detect misspelled words and suggest corrections.
+
+## Installation
+
+Install the Python dependencies with pip:
+
+```bash
+pip install pyspellchecker
+```
+
+## Usage
+
+You can check text passed as arguments, read from a file, or via standard input.
+
+```bash
+# Check text arguments
+python correxxt.py This is a smple txt
+
+# Check a file
+python correxxt.py -f path/to/file.txt
+
+# Or via stdin
+cat file.txt | python correxxt.py
+```
+
+The tool will output each misspelled word along with the most likely
+correction and a list of candidate suggestions.

--- a/correxxt.py
+++ b/correxxt.py
@@ -1,0 +1,37 @@
+import argparse
+import sys
+from spellchecker import SpellChecker
+
+
+def check_text(text: str) -> None:
+    spell = SpellChecker()
+    words = text.split()
+    misspelled = spell.unknown(words)
+    if not misspelled:
+        print("No spelling errors detected.")
+        return
+
+    for word in misspelled:
+        correction = spell.correction(word)
+        candidates = ", ".join(spell.candidates(word))
+        print(f"{word} -> {correction} (candidates: {candidates})")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Check spelling of text or files.")
+    parser.add_argument("text", nargs="*", help="Text to check. If omitted, reads from stdin or --file.")
+    parser.add_argument("-f", "--file", type=argparse.FileType('r'), help="File to read text from.")
+    args = parser.parse_args()
+
+    if args.file:
+        content = args.file.read()
+    elif args.text:
+        content = " ".join(args.text)
+    else:
+        content = sys.stdin.read()
+
+    check_text(content)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_correxxt.py
+++ b/tests/test_correxxt.py
@@ -1,0 +1,19 @@
+import subprocess
+import sys
+
+
+def run_correxxt(args):
+    result = subprocess.run([sys.executable, 'correxxt.py'] + args, capture_output=True, text=True)
+    assert result.returncode == 0
+    return result.stdout.strip()
+
+
+def test_correxxt_detects_errors():
+    out = run_correxxt(['Ths', 'is', 'a', 'tst'])
+    assert 'ths ->' in out
+    assert 'tst ->' in out
+
+
+def test_correxxt_no_errors():
+    out = run_correxxt(['This', 'is', 'fine'])
+    assert 'No spelling errors detected.' in out


### PR DESCRIPTION
## Summary
- add `correxxt.py` script that checks spelling via pyspellchecker
- document usage in README
- add tests for CLI
- ignore Python cache files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e94b81f8832991b21bc7b685cbff