### PR TITLE
Add customizable dictionary support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,17 @@ cat file.txt | python correxxt.py
 
 The tool will output each misspelled word along with the most likely
 correction and a list of candidate suggestions.
+
+### Custom dictionary
+
+You can maintain a file with custom words that should be treated as
+correct. Use `--dict` to specify the file and `--add-word` or
+`--remove-word` to manage entries:
+
+```bash
+# Create or update a custom dictionary
+python correxxt.py --dict mywords.txt --add-word foobar
+
+# Check text using that dictionary
+python correxxt.py --dict mywords.txt foobar
+```

--- a/correxxt.py
+++ b/correxxt.py
@@ -1,10 +1,26 @@
 import argparse
+from pathlib import Path
 import sys
+from typing import Iterable
 from spellchecker import SpellChecker
 
 
-def check_text(text: str) -> None:
+DEFAULT_DICT = Path("custom_words.txt")
+
+
+def load_custom_words(path: Path) -> set[str]:
+    if path.exists():
+        return {w.strip() for w in path.read_text().splitlines() if w.strip()}
+    return set()
+
+
+def save_custom_words(words: Iterable[str], path: Path) -> None:
+    path.write_text("\n".join(sorted(words)) + "\n")
+
+
+def check_text(text: str, dictionary: Path = DEFAULT_DICT) -> None:
     spell = SpellChecker()
+    spell.word_frequency.load_words(load_custom_words(dictionary))
     words = text.split()
     misspelled = spell.unknown(words)
     if not misspelled:
@@ -21,7 +37,33 @@ def main():
     parser = argparse.ArgumentParser(description="Check spelling of text or files.")
     parser.add_argument("text", nargs="*", help="Text to check. If omitted, reads from stdin or --file.")
     parser.add_argument("-f", "--file", type=argparse.FileType('r'), help="File to read text from.")
+    parser.add_argument("--dict", type=Path, default=DEFAULT_DICT, help="Custom dictionary file.")
+    parser.add_argument("--add-word", help="Add a word to the custom dictionary and exit.")
+    parser.add_argument("--remove-word", help="Remove a word from the custom dictionary and exit.")
+    parser.add_argument("--list-words", action="store_true", help="List words in the custom dictionary and exit.")
     args = parser.parse_args()
+
+    if args.add_word:
+        words = load_custom_words(args.dict)
+        words.add(args.add_word)
+        save_custom_words(words, args.dict)
+        print(f"Added '{args.add_word}' to {args.dict}")
+        return
+
+    if args.remove_word:
+        words = load_custom_words(args.dict)
+        if args.remove_word in words:
+            words.remove(args.remove_word)
+            save_custom_words(words, args.dict)
+            print(f"Removed '{args.remove_word}' from {args.dict}")
+        else:
+            print(f"Word '{args.remove_word}' not found in {args.dict}")
+        return
+
+    if args.list_words:
+        for word in sorted(load_custom_words(args.dict)):
+            print(word)
+        return
 
     if args.file:
         content = args.file.read()
@@ -30,7 +72,7 @@ def main():
     else:
         content = sys.stdin.read()
 
-    check_text(content)
+    check_text(content, args.dict)
 
 
 if __name__ == "__main__":

--- a/tests/test_correxxt.py
+++ b/tests/test_correxxt.py
@@ -17,3 +17,16 @@ def test_correxxt_detects_errors():
 def test_correxxt_no_errors():
     out = run_correxxt(['This', 'is', 'fine'])
     assert 'No spelling errors detected.' in out
+
+
+def test_custom_dictionary(tmp_path):
+    dict_file = tmp_path / 'dict.txt'
+    # Add a word and ensure it is recognised
+    run_correxxt(['--dict', str(dict_file), '--add-word', 'tst'])
+    out = run_correxxt(['--dict', str(dict_file), 'tst'])
+    assert 'No spelling errors detected.' in out
+
+    # Remove the word and check again
+    run_correxxt(['--dict', str(dict_file), '--remove-word', 'tst'])
+    out = run_correxxt(['--dict', str(dict_file), 'tst'])
+    assert 'tst ->' in out


### PR DESCRIPTION
## Summary
- allow users to keep a custom dictionary file
- expose commands to add, remove, and list custom words
- document the new feature in README
- cover custom dictionary workflow in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845f8dadf98832991186d21bf5d8014